### PR TITLE
Fixed issue #2 — Typo on add_settings_field() function

### DIFF
--- a/admin/functions-settings.php
+++ b/admin/functions-settings.php
@@ -30,7 +30,7 @@ function mrh_register_settings() {
 		'mrh_role_hierarchy',
 		esc_html__( 'Role Hierarchy', 'members-role-hierarchy' ),
 		'mrh_settings_field_hierarchy',
-		'settings_page_members-settings',
+		'members-settings',
 		'roles_caps'
 	);
 }


### PR DESCRIPTION
Changed page parameter value of `"settings_page_members-settings"` to `"members-settings"` in `add_settings_field()` to allow hierarchy settings to show on main Members plugin settings page.